### PR TITLE
fix: 修复 'networkidle0' 在 http2 下长连接超时问题

### DIFF
--- a/src/lib/pdf/generate-pdf.ts
+++ b/src/lib/pdf/generate-pdf.ts
@@ -366,7 +366,7 @@ export async function generatePdf(html: string, options: PdfOptions = {}): Promi
     // Set viewport to A4 width before loading content for accurate layout
     await page.setViewport({ width: A4_WIDTH_PX, height: A4_HEIGHT_PX });
 
-    await page.setContent(html, { waitUntil: 'networkidle0', timeout: 15000 });
+    await page.setContent(html, { waitUntil: 'domcontentloaded', timeout: 15000 });
 
     // Wait for web fonts (e.g. Noto Sans SC) to finish loading
     await page.evaluate(() => document.fonts.ready);


### PR DESCRIPTION
# 问题背景

在生成 PDF 时，当前代码使用了：
```
await page.setContent(html, { waitUntil: 'networkidle0', timeout: timeoutMs });
```
在部分环境中偶尔会出现如下错误：
```
TimeoutError: Navigation timeout of 15000 ms exceeded
```
通过调试发现：

页面所有 request 都已经 finished
但 page.setContent 仍然在等待
最终触发 timeout

该问题具有 随机性：
同样的 HTML，有时正常，有时超时。

# 原因分析

networkidle0 的定义是：连续 500ms 没有任何网络连接

但在现代浏览器中，即使请求已经完成，TCP 连接也不会立即关闭，原因包括：

1. Connection Pooling（连接池）

  浏览器会将 TCP 连接放入连接池，以便后续复用：
  ```
  HTTP request finished
  ↓
  connection kept alive
  ↓
  waiting for reuse
  ```
  此时请求虽然结束，但连接仍然存在。

2. HTTP Keep-Alive / HTTP2

  现代浏览器大量使用：
  
  HTTP Keep-Alive
  HTTP/2 multiplexing
  
  这些机制都会导致连接保持一段时间，例如：
  
  fonts.googleapis.com
  fonts.gstatic.com
  
  尤其是 Web Font（例如 Noto Sans SC）加载时，Chrome 经常保持连接以便后续字体请求。

3. Chrome Socket Pool 行为

  Chrome 内部维护一个 socket pool：
  
  host
   ├─ active connection
   └─ idle connection
  
  即使所有请求结束，只要连接仍在 pool 中：
  
  networkidle0 仍认为存在 network activity
  
  因此 page.setContent 会继续等待。

# 为什么该问题是随机的

连接何时关闭由浏览器和网络环境共同决定，例如：

- Chrome connection pool 策略
- HTTP2 keep-alive
- CDN 行为
- 操作系统 TCP 调度
- 网络延迟

因此会出现：

同一段代码
昨天超时
今天正常

即 非确定性行为。

# 为什么 HTML → PDF 不需要 networkidle0

在服务器端 HTML 渲染 PDF 时，我们真正需要保证的是：

DOM 已解析完成

Web Font 已加载完成

并不需要等待所有网络连接完全关闭。

# 解决方案

将：
```
await page.setContent(html, { waitUntil: 'networkidle0', timeout: timeoutMs });
```
替换为：
```
await page.setContent(html, {
  waitUntil: 'domcontentloaded',
  timeout: timeoutMs,
});

// 等待 Web Font 加载完成
await page.evaluate(() => document.fonts.ready);
```
修改后的行为

新逻辑保证：
```
DOM ready
+
fonts ready
```
即可开始 PDF 渲染。

避免了 networkidle0 因连接池导致的随机等待问题。