### PR TITLE
fix(ai): 修复 JD 匹配分析因 KEY_ALIASES 导致 JSON 解析失败的 Bug

### DIFF
--- a/src/lib/ai/extract-json.ts
+++ b/src/lib/ai/extract-json.ts
@@ -90,7 +90,7 @@ const KEY_ALIASES: Record<string, string> = {
   abilityScores: 'dimensionScores',
   rounds: 'roundEvaluations',
   evaluations: 'roundEvaluations',
-  summary: 'overallFeedback',
+  //summary: 'overallFeedback',
   feedback: 'overallFeedback',
   overallSummary: 'overallFeedback',
   improvements: 'improvementPlan',


### PR DESCRIPTION
## 问题描述 (Description)
在使用“JD 匹配分析”功能时，后端持续抛出 `Failed to extract valid JSON` 以及 Zod 校验错误：`Invalid input: expected string, received undefined` (path: summary)。

经过排查发现，AI 模型（如 DeepSeek、GPT）已正确输出了符合 `jdAnalysisOutputSchema` 要求的 `summary` 字段，但在进入 Zod 校验前，被 `src/lib/ai/extract-json.ts` 中的 `KEY_ALIASES` 拦截器强行重命名为了 `overallFeedback`。这导致后续的 Zod schema 找不到 `summary` 字段而直接崩溃。

## 修复方案 (Solution)
移除了 `KEY_ALIASES` 中对 `summary` 字段的不当映射，保留 AI 生成的原始字段名，使其能够顺利通过 `jdAnalysisOutputSchema` 的校验。

## 测试 (Testing)
- [x] 本地通过 Docker 重新构建测试
- [x] JD 匹配分析功能恢复正常，JSON 可被成功解析并渲染报告