### PR TITLE
feat(interview): view completed session history (clean re-roll of #54 + round-status fix)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -785,6 +785,7 @@
       "continue": "Continue",
       "start": "Start Interview",
       "viewReport": "View Report",
+      "viewRecord": "View Record",
       "deleteConfirm": "Are you sure you want to delete this interview? This action cannot be undone."
     },
     "setup": {

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -785,6 +785,7 @@
       "continue": "继续面试",
       "start": "进入面试",
       "viewReport": "查看报告",
+      "viewRecord": "查看面试记录",
       "deleteConfirm": "确定要删除这场面试记录吗？此操作不可恢复。"
     },
     "setup": {

--- a/src/app/api/interview/[id]/chat/route.ts
+++ b/src/app/api/interview/[id]/chat/route.ts
@@ -85,6 +85,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
         await interviewRepository.incrementQuestionCount(roundId);
 
         if (text.includes('[ROUND_COMPLETE]')) {
+          await interviewRepository.updateRoundStatus(roundId, 'completed');
           await interviewRepository.setRoundSummary(roundId, {
             score: 0,
             feedback: text.replace('[ROUND_COMPLETE]', '').trim(),

--- a/src/components/interview/interview-card.tsx
+++ b/src/components/interview/interview-card.tsx
@@ -134,11 +134,18 @@ export function InterviewCard({ session, onDelete }: InterviewCardProps) {
       {/* Action + date + delete */}
       <div className="flex items-center gap-2">
         {isCompleted ? (
-          <Link href={`/interview/${session.id}/report`} className="flex-1">
-            <Button variant="outline" size="sm" className="w-full rounded-lg border-brand-muted text-xs text-brand hover:bg-brand-muted dark:border-brand-muted dark:text-brand dark:hover:bg-brand-muted">
-              {t('lobby.viewReport')}
-            </Button>
-          </Link>
+          <>
+            <Link href={`/interview/${session.id}`} className="flex-1">
+              <Button variant="outline" size="sm" className="w-full rounded-lg border-brand-muted text-xs text-brand hover:bg-brand-muted dark:border-brand-muted dark:text-brand dark:hover:bg-brand-muted">
+                {t('lobby.viewRecord')}
+              </Button>
+            </Link>
+            <Link href={`/interview/${session.id}/report`} className="flex-1">
+              <Button variant="outline" size="sm" className="w-full rounded-lg border-brand-muted text-xs text-brand hover:bg-brand-muted dark:border-brand-muted dark:text-brand dark:hover:bg-brand-muted">
+                {t('lobby.viewReport')}
+              </Button>
+            </Link>
+          </>
         ) : (
           <Link href={`/interview/${session.id}`} className="flex-1">
             <Button size="sm" className="w-full rounded-lg bg-brand text-xs hover:bg-brand-hover">

--- a/src/components/interview/interview-room.tsx
+++ b/src/components/interview/interview-room.tsx
@@ -8,6 +8,7 @@ import { useInterviewStore } from '@/stores/interview-store';
 import { useInterviewChat } from '@/hooks/use-interview-chat';
 import { useSettingsStore } from '@/stores/settings-store';
 import { INIT_TRIGGER } from '@/lib/interview/constants';
+import { isRoundViewOnly } from '@/lib/interview/round-status';
 import { ProgressBar } from './progress-bar';
 import { InterviewerBanner } from './interviewer-banner';
 import { MessageList } from './message-list';
@@ -36,14 +37,14 @@ interface InterviewRoomProps {
 export function InterviewRoom({ sessionId, initialMessages }: InterviewRoomProps) {
   const t = useTranslations('interview.room');
   const router = useRouter();
-  const { rounds, currentRoundIndex, setCurrentRoundIndex, advanceToNextRound, setIsGeneratingReport } =
+  const { rounds, currentRoundIndex, setCurrentRoundIndex, advanceToNextRound, setIsGeneratingReport, status: sessionStatus } =
     useInterviewStore();
   const [showTransition, setShowTransition] = useState(false);
   const [isViewingHistory, setIsViewingHistory] = useState(false);
 
   const currentRound = rounds[currentRoundIndex];
   const interviewerConfig = currentRound?.interviewerConfig as InterviewerConfig;
-  const isRoundDone = currentRound?.status === 'completed' || currentRound?.status === 'skipped';
+  const isRoundDone = isRoundViewOnly(currentRound?.status, sessionStatus);
 
   const { messages, input, handleInputChange, handleSubmit, isLoading, resetMessages, sendMessage, setMessages } =
     useInterviewChat({
@@ -80,7 +81,7 @@ export function InterviewRoom({ sessionId, initialMessages }: InterviewRoomProps
 
   // Auto-set viewing history if round is already done
   useEffect(() => {
-    if (currentRound && (currentRound.status === 'completed' || currentRound.status === 'skipped')) {
+    if (currentRound && isRoundDone) {
       setIsViewingHistory(true);
       setShowTransition(false);
       loadedRef.current = true;
@@ -125,14 +126,14 @@ export function InterviewRoom({ sessionId, initialMessages }: InterviewRoomProps
       setMessages([]);
     }
 
-    const isDone = targetRound.status === 'completed' || targetRound.status === 'skipped';
+    const isDone = isRoundViewOnly(targetRound.status, sessionStatus);
     setIsViewingHistory(isDone);
     if (isDone) setShowTransition(false);
 
     // Reset init refs
     loadedRef.current = true;
     sentInitRef.current = targetRound.id;
-  }, [rounds, sessionId, setCurrentRoundIndex, setMessages]);
+  }, [rounds, sessionId, sessionStatus, setCurrentRoundIndex, setMessages]);
 
   const handleNextRound = useCallback(() => {
     setShowTransition(false);

--- a/src/components/interview/interview-room.tsx
+++ b/src/components/interview/interview-room.tsx
@@ -78,6 +78,15 @@ export function InterviewRoom({ sessionId, initialMessages }: InterviewRoomProps
     }
   }, [currentRound?.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Auto-set viewing history if round is already done
+  useEffect(() => {
+    if (currentRound && (currentRound.status === 'completed' || currentRound.status === 'skipped')) {
+      setIsViewingHistory(true);
+      setShowTransition(false);
+      loadedRef.current = true;
+    }
+  }, [currentRound?.id]); // eslint-disable-line react-hooks/exhaustive-deps
+
   // Detect round completion
   useEffect(() => {
     if (!messages.length || isLoading || isViewingHistory) return;
@@ -118,6 +127,7 @@ export function InterviewRoom({ sessionId, initialMessages }: InterviewRoomProps
 
     const isDone = targetRound.status === 'completed' || targetRound.status === 'skipped';
     setIsViewingHistory(isDone);
+    if (isDone) setShowTransition(false);
 
     // Reset init refs
     loadedRef.current = true;
@@ -161,7 +171,7 @@ export function InterviewRoom({ sessionId, initialMessages }: InterviewRoomProps
 
   const isLastRound = currentRoundIndex >= rounds.length - 1;
 
-  if (showTransition) {
+  if (showTransition && !isViewingHistory) {
     const nextRound = rounds[currentRoundIndex + 1];
     return (
       <div className="mx-auto max-w-4xl space-y-4">

--- a/src/lib/interview/round-status.test.ts
+++ b/src/lib/interview/round-status.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { isRoundViewOnly } from './round-status';
+
+describe('isRoundViewOnly', () => {
+  it('returns true for a completed round', () => {
+    expect(isRoundViewOnly('completed', 'in_progress')).toBe(true);
+  });
+
+  it('returns true for a skipped round', () => {
+    expect(isRoundViewOnly('skipped', 'in_progress')).toBe(true);
+  });
+
+  it('returns false for an active round in an active session', () => {
+    expect(isRoundViewOnly('in_progress', 'in_progress')).toBe(false);
+    expect(isRoundViewOnly('pending', 'in_progress')).toBe(false);
+    expect(isRoundViewOnly('in_progress', 'paused')).toBe(false);
+  });
+
+  // Legacy data: rounds finished via AI [ROUND_COMPLETE] were never marked
+  // completed in the DB, so a completed session must always be view-only.
+  it('returns true for any round once the session is completed', () => {
+    expect(isRoundViewOnly('in_progress', 'completed')).toBe(true);
+    expect(isRoundViewOnly('pending', 'completed')).toBe(true);
+    expect(isRoundViewOnly('completed', 'completed')).toBe(true);
+  });
+
+  it('returns false when round is missing', () => {
+    expect(isRoundViewOnly(undefined, 'completed')).toBe(true);
+    expect(isRoundViewOnly(undefined, 'in_progress')).toBe(false);
+  });
+});

--- a/src/lib/interview/round-status.ts
+++ b/src/lib/interview/round-status.ts
@@ -1,0 +1,16 @@
+import type { InterviewRoundStatus, InterviewSessionStatus } from '@/types/interview';
+
+/**
+ * Whether a round should be shown in read-only history mode.
+ *
+ * A completed session is always view-only, regardless of round status:
+ * rounds finished via the AI's [ROUND_COMPLETE] marker may still be
+ * 'in_progress' in the DB (legacy data), so round status alone is not enough.
+ */
+export function isRoundViewOnly(
+  roundStatus: InterviewRoundStatus | undefined,
+  sessionStatus: string | undefined,
+): boolean {
+  if ((sessionStatus as InterviewSessionStatus) === 'completed') return true;
+  return roundStatus === 'completed' || roundStatus === 'skipped';
+}


### PR DESCRIPTION
## 变更内容

PR #54 的干净版本（cherry-pick 自该 PR，保留原作者 @c524069797 的功能提交署名），并在 #70 的 vitest 基建之上补齐了单元测试。

**用这个 PR 替代 #54 的原因**：#54 的分支历史中包含一个误提交的本地 SQLite 数据库（`data/jade.db`，commit a3c0645，内含真实个人数据），即使后续提交已删除该文件，普通 merge 仍会把这个 blob 带进 main 的历史。本 PR 的历史完全不含该文件。

### 功能（来自 #54，作者 @c524069797）
- 面试卡片：已完成面试新增「查看面试记录」按钮，与「查看报告」并列
- 面试房间：访问已完成的面试自动进入回顾模式，显示历史对话，不再出现输入框/过渡页
- 新增 `lobby.viewRecord` 中英文翻译键

### 修复（验证 #54 时发现）
- **治根**：`chat/route.ts` 的 `[ROUND_COMPLETE]` 路径此前从不把轮次标记为 `completed`（只有手动「结束本轮」才会），导致 AI 自然完成的面试看不到历史，仍显示「生成面试报告」过渡页
- **兜底**：新增 `isRoundViewOnly(roundStatus, sessionStatus)` —— 会话已完成则一律只读回顾，覆盖轮次状态未被标记的存量数据
- 单测：`src/lib/interview/round-status.test.ts`（5 cases）

## 测试

- `pnpm test`：11 passed（含 main 原有 tools 测试）
- `tsc --noEmit` 通过
- 浏览器实测三种状态（手动结束 / AI 自然完成 / 进行中）均符合预期，验证记录见 #54 评论

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)
