### PR TITLE
feat(jd-analysis): add copy-and-optimize alongside in-place optimize

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -348,6 +348,8 @@
     "currentState": "Current",
     "suggestedChange": "Suggested",
     "optimize": "Optimize Resume",
+    "optimizeCopy": "Copy & Optimize",
+    "copyOptimizeError": "Failed to duplicate resume, please try again",
     "pasteJd": "Paste a job description to get started",
     "noResults": "No analysis results available",
     "newAnalysis": "New Analysis",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -348,6 +348,8 @@
     "currentState": "当前",
     "suggestedChange": "建议",
     "optimize": "一键优化",
+    "optimizeCopy": "复制优化",
+    "copyOptimizeError": "复制简历失败，请重试",
     "pasteJd": "粘贴职位描述以开始分析",
     "noResults": "暂无分析结果",
     "newAnalysis": "新分析",

--- a/src/app/[locale]/editor/[id]/page.tsx
+++ b/src/app/[locale]/editor/[id]/page.tsx
@@ -27,6 +27,7 @@ import { useEditorStore } from '@/stores/editor-store';
 import { useUIStore } from '@/stores/ui-store';
 import { useSettingsStore } from '@/stores/settings-store';
 import { useTourStore, hasCompletedTour } from '@/stores/tour-store';
+import { takePendingOptimizeMessage } from '@/lib/pending-optimize';
 import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
 
@@ -44,7 +45,7 @@ export default function EditorPage({ params }: { params: Promise<{ id: string }>
   const { resume, sections, updateSection, addSection, removeSection, reorderSections } = useEditor(id);
   const isMobile = useIsMobile();
   const [sidebarOpen, setSidebarOpen] = useState(false);
-  const { showThemeEditor, mobileActiveTab } = useEditorStore();
+  const { showThemeEditor, mobileActiveTab, setPendingAiMessage, setShowAiChat } = useEditorStore();
   const { activeModal, openModal, closeModal } = useUIStore();
   const { hydrate, _hydrated } = useSettingsStore();
   const startTour = useTourStore((s) => s.startTour);
@@ -78,6 +79,17 @@ export default function EditorPage({ params }: { params: Promise<{ id: string }>
     const timer = setTimeout(() => startTour('editor', EDITOR_TOUR_STEPS.length), 1000);
     return () => clearTimeout(timer);
   }, [resume, startTour]);
+
+  // Consume a copy-optimize message handed off via pending-optimize.ts (gated
+  // on resume.id === id so it runs after useEditor's cleanup for the old id).
+  useEffect(() => {
+    if (!resume || resume.id !== id) return;
+    const message = takePendingOptimizeMessage(id);
+    if (message) {
+      setPendingAiMessage(message);
+      setShowAiChat(true);
+    }
+  }, [resume, id, setPendingAiMessage, setShowAiChat]);
 
   if (fpLoading || !resume) {
     return (

--- a/src/components/ai/ai-chat-panel.tsx
+++ b/src/components/ai/ai-chat-panel.tsx
@@ -93,26 +93,40 @@ export function AIChatContent({ resumeId, hideTitle }: AIChatContentProps) {
       });
   }, [hydrated, settingsProvider, settingsBaseURL, settingsApiKey, settingsModel]);
 
-  // Fetch sessions on mount
+  // Fetch sessions for resumeId; reset state synchronously first so stale
+  // sessionsLoaded/activeSessionId can't leak a pendingAiMessage to the wrong resume.
   useEffect(() => {
+    setSessionsLoaded(false);
+    setActiveSessionId(undefined);
+    setSessions([]);
+    setInitialMessages(undefined);
+    resetPagination();
+
+    let cancelled = false;
     const headers = getHeaders();
     fetch(`/api/ai/chat/sessions?resumeId=${resumeId}`, { headers })
       .then((res) => res.json())
       .then(async (data: { sessions: ChatSession[] }) => {
+        if (cancelled) return;
         if (data.sessions.length > 0) {
           setSessions(data.sessions);
           const mostRecent = data.sessions[0];
           setActiveSessionId(mostRecent.id);
           const msgs = await loadInitial(mostRecent.id);
+          if (cancelled) return;
           setInitialMessages(msgs);
-        } else {
+        } else if (!cancelled) {
           await createNewSession(true);
         }
-        setSessionsLoaded(true);
+        if (!cancelled) setSessionsLoaded(true);
       })
       .catch(() => {
-        setSessionsLoaded(true);
+        if (!cancelled) setSessionsLoaded(true);
       });
+
+    return () => {
+      cancelled = true;
+    };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resumeId]);
 

--- a/src/components/editor/jd-analysis-dialog.tsx
+++ b/src/components/editor/jd-analysis-dialog.tsx
@@ -2,9 +2,11 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import { useRouter } from '@/i18n/routing';
 import {
   Loader2, RotateCcw, Target, ShieldCheck, Lightbulb, AlertTriangle,
-  Wand2, Trash2, FileSearch, ArrowUp, ArrowDown, Minus, ChevronLeft,
+  Wand2, Copy, Trash2, FileSearch, ArrowUp, ArrowDown, Minus, ChevronLeft,
   Briefcase, ChevronDown,
 } from 'lucide-react';
 import {
@@ -30,6 +32,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Badge } from '@/components/ui/badge';
 import { useEditorStore } from '@/stores/editor-store';
 import { getAIHeaders } from '@/stores/settings-store';
+import { setPendingOptimizeMessage } from '@/lib/pending-optimize';
 
 interface JdAnalysisResult {
   overallScore: number;
@@ -266,11 +269,13 @@ function JdAnalysisResultView({ result, jobDescription, t }: { result: JdAnalysi
 export function JdAnalysisDialog({ open, onOpenChange, resumeId }: JdAnalysisDialogProps) {
   const t = useTranslations('jdAnalysis');
   const ct = useTranslations('common');
+  const router = useRouter();
   const { setShowAiChat, setPendingAiMessage } = useEditorStore();
   const [jobDescription, setJobDescription] = useState('');
   const [isAnalyzing, setIsAnalyzing] = useState(false);
   const [result, setResult] = useState<JdAnalysisResult | null>(null);
   const [error, setError] = useState('');
+  const [isDuplicating, setIsDuplicating] = useState(false);
 
   // History state
   const [activeTab, setActiveTab] = useState<string>('new');
@@ -357,24 +362,55 @@ export function JdAnalysisDialog({ open, onOpenChange, resumeId }: JdAnalysisDia
     }, 200);
   };
 
-  const handleOptimize = () => {
-    if (!result) return;
+  const buildOptimizeMessage = (r: JdAnalysisResult) => {
     const parts: string[] = [];
-    if (result.missingKeywords.length > 0) {
-      parts.push(`缺失关键词：${result.missingKeywords.join('、')}`);
+    if (r.missingKeywords.length > 0) {
+      parts.push(`缺失关键词：${r.missingKeywords.join('、')}`);
     }
-    if (result.suggestions.length > 0) {
-      const list = result.suggestions
+    if (r.suggestions.length > 0) {
+      const list = r.suggestions
         .map((s, i) => `${i + 1}. [${s.section}] "${s.current}" → "${s.suggested}"`)
         .join('\n');
       parts.push(`优化建议：\n${list}`);
     }
-    const message = `请根据以下 JD 匹配分析结果优化简历，使其更匹配目标职位：\n\n${parts.join('\n\n')}\n\n请使用工具直接修改对应的简历模块内容，尽量自然地融入缺失关键词。`;
+    return `请根据以下 JD 匹配分析结果优化简历，使其更匹配目标职位：\n\n${parts.join('\n\n')}\n\n请使用工具直接修改对应的简历模块内容，尽量自然地融入缺失关键词。`;
+  };
+
+  const handleOptimize = () => {
+    if (!result) return;
+    const message = buildOptimizeMessage(result);
     onOpenChange(false);
     setTimeout(() => {
       setPendingAiMessage(message);
       setShowAiChat(true);
     }, 300);
+  };
+
+  const handleOptimizeCopy = async () => {
+    if (!result || isDuplicating) return;
+    const message = buildOptimizeMessage(result);
+    setIsDuplicating(true);
+    try {
+      const res = await fetch(`/api/resume/${resumeId}/duplicate`, {
+        method: 'POST',
+        headers: getAuthHeaders(),
+      });
+      if (!res.ok) throw new Error('Failed to duplicate resume');
+      const duplicated = await res.json();
+      setPendingOptimizeMessage(duplicated.id, message);
+      onOpenChange(false);
+      setTimeout(() => {
+        setResult(null);
+        setJobDescription('');
+        setError('');
+        setActiveTab('new');
+      }, 200);
+      router.push(`/editor/${duplicated.id}`);
+    } catch {
+      toast.error(t('copyOptimizeError'));
+    } finally {
+      setIsDuplicating(false);
+    }
   };
 
   const handleDeleteHistory = async (id: string) => {
@@ -470,10 +506,25 @@ export function JdAnalysisDialog({ open, onOpenChange, resumeId }: JdAnalysisDia
                     {t('analyzeAgain')}
                   </Button>
                   {(result.suggestions.length > 0 || result.missingKeywords.length > 0) && (
-                    <Button onClick={handleOptimize} className="cursor-pointer gap-1.5 bg-brand hover:bg-brand-hover">
-                      <Wand2 className="h-3.5 w-3.5" />
-                      {t('optimize')}
-                    </Button>
+                    <>
+                      <Button
+                        variant="outline"
+                        onClick={handleOptimizeCopy}
+                        disabled={isDuplicating}
+                        className="cursor-pointer gap-1.5"
+                      >
+                        {isDuplicating ? (
+                          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        ) : (
+                          <Copy className="h-3.5 w-3.5" />
+                        )}
+                        {t('optimizeCopy')}
+                      </Button>
+                      <Button onClick={handleOptimize} className="cursor-pointer gap-1.5 bg-brand hover:bg-brand-hover">
+                        <Wand2 className="h-3.5 w-3.5" />
+                        {t('optimize')}
+                      </Button>
+                    </>
                   )}
                 </div>
               </>

--- a/src/lib/pending-optimize.ts
+++ b/src/lib/pending-optimize.ts
@@ -1,0 +1,20 @@
+"use client";
+
+/** "Copy & optimize": handoff for an AI message across a resume-duplicate
+ * navigation, since editor-store's pendingAiMessage gets reset by
+ * useEditor's cleanup when the route's resumeId changes. */
+
+const PREFIX = "jade:pending-optimize:";
+
+export function setPendingOptimizeMessage(resumeId: string, message: string) {
+  if (typeof window === "undefined") return;
+  window.sessionStorage.setItem(PREFIX + resumeId, message);
+}
+
+export function takePendingOptimizeMessage(resumeId: string): string | null {
+  if (typeof window === "undefined") return null;
+  const key = PREFIX + resumeId;
+  const message = window.sessionStorage.getItem(key);
+  if (message !== null) window.sessionStorage.removeItem(key);
+  return message;
+}


### PR DESCRIPTION
- 复制优化按钮位于一键优化左侧：复制简历 -> 跳转新编辑器 -> 自动开始优化对话
- 新增 src/lib/pending-optimize.ts，用 sessionStorage 跨导航传递待发送消息
- 修复 ai-chat-panel.tsx sessions-fetch 竞态：resumeId 变化时同步重置 session 状态，避免 pending 消息发到旧 session