### PR TITLE
fix: handle missing AI configuration across features

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -266,6 +266,8 @@
       "baseURL": "Base URL",
       "model": "Default Model",
       "modelPlaceholder": "Enter model name...",
+      "modelsMissingApiKey": "Enter an API Key first to fetch available models.",
+      "modelsFetchError": "Failed to fetch models. Check the Base URL and API Key.",
       "noModelsFound": "No models found. Enter a model name manually below."
     },
     "appearance": {
@@ -840,6 +842,9 @@
       "generating": "Interviewer is thinking...",
       "roundComplete": "This round is complete",
       "allComplete": "All interview rounds completed",
+      "chatErrorTitle": "AI message failed to send",
+      "chatErrorHint": "Check the API Key, Base URL, and model in Settings, then try again.",
+      "openAISettings": "Check AI settings",
       "generateReport": "Generate Report",
       "generatingReport": "Generating report..."
     },
@@ -877,6 +882,11 @@
       "stable": "Stable",
       "exportPdf": "Export PDF",
       "exportMarkdown": "Export Markdown",
+      "generationErrorTitle": "Failed to generate interview report",
+      "generationErrorHint": "Check the API Key, Base URL, and model in Settings, then try again.",
+      "generationError": "Failed to generate report",
+      "loadError": "Failed to load report",
+      "openAISettings": "Check AI settings",
       "backToLobby": "Back to Lobby",
       "markedForReview": "Marked for Review",
       "usedHint": "Used Hint",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -266,6 +266,8 @@
       "baseURL": "API 地址",
       "model": "默认模型",
       "modelPlaceholder": "输入模型名称...",
+      "modelsMissingApiKey": "请先填写 API Key，再获取模型列表。",
+      "modelsFetchError": "模型列表获取失败，请检查 API 地址和 API Key。",
       "noModelsFound": "未找到模型，请在下方手动输入模型名称。"
     },
     "appearance": {
@@ -840,6 +842,9 @@
       "generating": "面试官正在思考...",
       "roundComplete": "本轮面试结束",
       "allComplete": "所有面试轮次已完成",
+      "chatErrorTitle": "AI 对话发送失败",
+      "chatErrorHint": "请检查设置中的 API Key、Base URL 和模型是否正确，然后重试。",
+      "openAISettings": "检查 AI 配置",
       "generateReport": "生成面试报告",
       "generatingReport": "正在生成报告..."
     },
@@ -877,6 +882,11 @@
       "stable": "持平",
       "exportPdf": "导出 PDF",
       "exportMarkdown": "导出 Markdown",
+      "generationErrorTitle": "面试报告生成失败",
+      "generationErrorHint": "请检查设置中的 API Key、Base URL 和模型是否正确，然后重试。",
+      "generationError": "报告生成失败",
+      "loadError": "报告加载失败",
+      "openAISettings": "检查 AI 配置",
       "backToLobby": "返回面试大厅",
       "markedForReview": "标记复习",
       "usedHint": "使用了提示",

--- a/src/app/[locale]/interview/[id]/report/page.tsx
+++ b/src/app/[locale]/interview/[id]/report/page.tsx
@@ -1,9 +1,13 @@
 'use client';
 
 import { use, useEffect, useState } from 'react';
+import { AlertTriangle, Settings } from 'lucide-react';
 import { InterviewReportView } from '@/components/interview/interview-report';
 import { Skeleton } from '@/components/ui/skeleton';
+import { Button } from '@/components/ui/button';
 import { useSettingsStore, getAIHeaders } from '@/stores/settings-store';
+import { useUIStore } from '@/stores/ui-store';
+import { useTranslations } from 'next-intl';
 import type { InterviewReport, InterviewSession } from '@/types/interview';
 
 export default function ReportPage({ params }: { params: Promise<{ id: string }> }) {
@@ -11,7 +15,10 @@ export default function ReportPage({ params }: { params: Promise<{ id: string }>
   const [report, setReport] = useState<InterviewReport | null>(null);
   const [session, setSession] = useState<InterviewSession | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
   const hydrated = useSettingsStore((s) => s._hydrated);
+  const { openModal, setSettingsTab } = useUIStore();
+  const t = useTranslations('interview.report');
 
   useEffect(() => {
     if (!hydrated) return;
@@ -24,7 +31,11 @@ export default function ReportPage({ params }: { params: Promise<{ id: string }>
     };
 
     fetch(`/api/interview/${id}`, { headers })
-      .then((r) => r.json())
+      .then(async (res) => {
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) throw new Error(data.error || t('loadError'));
+        return data;
+      })
       .then(({ session: s, report: r }) => {
         setSession(s);
         if (r) {
@@ -36,17 +47,22 @@ export default function ReportPage({ params }: { params: Promise<{ id: string }>
             headers,
             body: JSON.stringify({ locale: document.documentElement.lang || 'zh' }),
           })
-            .then((res) => res.json())
+            .then(async (res) => {
+              const data = await res.json().catch(() => ({}));
+              if (!res.ok) throw new Error(data.error || t('generationError'));
+              return data as InterviewReport;
+            })
             .then((data) => setReport(data))
-            .catch(console.error)
+            .catch((err) => setError(err instanceof Error ? err.message : t('generationError')))
             .finally(() => setLoading(false));
         }
       })
       .catch((err) => {
         console.error(err);
+        setError(err instanceof Error ? err.message : t('loadError'));
         setLoading(false);
       });
-  }, [id, hydrated]);
+  }, [id, hydrated, t]);
 
   if (loading) {
     return (
@@ -58,8 +74,29 @@ export default function ReportPage({ params }: { params: Promise<{ id: string }>
     );
   }
 
+  if (error) {
+    return (
+      <div role="alert" className="mx-auto flex max-w-xl flex-col items-center gap-3 py-20 text-center">
+        <AlertTriangle className="h-8 w-8 text-amber-500" />
+        <h1 className="text-lg font-semibold text-zinc-800 dark:text-zinc-200">{t('generationErrorTitle')}</h1>
+        <p className="text-sm text-zinc-500 dark:text-zinc-400">{t('generationErrorHint')}</p>
+        <p className="max-w-full break-words text-xs text-zinc-400">{error}</p>
+        <Button
+          variant="outline"
+          onClick={() => {
+            setSettingsTab('ai');
+            openModal('settings');
+          }}
+        >
+          <Settings className="mr-1.5 h-4 w-4" />
+          {t('openAISettings')}
+        </Button>
+      </div>
+    );
+  }
+
   if (!report || !session) {
-    return <div className="py-20 text-center text-zinc-500">Failed to load report</div>;
+    return <div className="py-20 text-center text-zinc-500">{t('loadError')}</div>;
   }
 
   return <InterviewReportView report={report} session={session} />;

--- a/src/app/api/ai/models/route.ts
+++ b/src/app/api/ai/models/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from 'next/server';
+import { normalizeAIBaseURL } from '@/lib/ai/provider';
 
 export async function GET(request: NextRequest) {
   const provider = request.headers.get('x-provider') || 'openai';
@@ -44,7 +45,7 @@ export async function GET(request: NextRequest) {
 
       default: {
         // openai
-        const effectiveBaseURL = baseURL || 'https://api.openai.com/v1';
+        const effectiveBaseURL = normalizeAIBaseURL(provider, baseURL || 'https://api.openai.com/v1');
         const res = await fetch(`${effectiveBaseURL}/models`, {
           headers: { Authorization: `Bearer ${apiKey}` },
         });

--- a/src/app/api/ai/models/route.ts
+++ b/src/app/api/ai/models/route.ts
@@ -6,7 +6,7 @@ export async function GET(request: NextRequest) {
   const baseURL = request.headers.get('x-base-url') || '';
 
   if (!apiKey) {
-    return Response.json({ models: [] });
+    return Response.json({ models: [], error: 'API key is required. Please configure it in Settings.' }, { status: 401 });
   }
 
   try {

--- a/src/app/api/interview/[id]/chat/route.ts
+++ b/src/app/api/interview/[id]/chat/route.ts
@@ -71,8 +71,13 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
 
     const result = streamText({
       model,
+      maxRetries: 0,
+      timeout: 60_000,
       system: systemPrompt,
       messages: modelMessages,
+      onError: ({ error }) => {
+        console.error('Interview AI stream error:', error);
+      },
       onFinish: async ({ text }) => {
         if (!text) return;
 

--- a/src/components/interview/interview-room.tsx
+++ b/src/components/interview/interview-room.tsx
@@ -3,10 +3,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import type { UIMessage } from 'ai';
+import { AlertTriangle, Settings } from 'lucide-react';
 import { useRouter } from '@/i18n/routing';
 import { useInterviewStore } from '@/stores/interview-store';
 import { useInterviewChat } from '@/hooks/use-interview-chat';
 import { useSettingsStore } from '@/stores/settings-store';
+import { useUIStore } from '@/stores/ui-store';
 import { INIT_TRIGGER } from '@/lib/interview/constants';
 import { isRoundViewOnly } from '@/lib/interview/round-status';
 import { ProgressBar } from './progress-bar';
@@ -37,6 +39,8 @@ interface InterviewRoomProps {
 export function InterviewRoom({ sessionId, initialMessages }: InterviewRoomProps) {
   const t = useTranslations('interview.room');
   const router = useRouter();
+  const { openModal, setSettingsTab } = useUIStore();
+  const selectedModel = useSettingsStore((state) => state.aiModel);
   const { rounds, currentRoundIndex, setCurrentRoundIndex, advanceToNextRound, setIsGeneratingReport, status: sessionStatus } =
     useInterviewStore();
   const [showTransition, setShowTransition] = useState(false);
@@ -46,11 +50,11 @@ export function InterviewRoom({ sessionId, initialMessages }: InterviewRoomProps
   const interviewerConfig = currentRound?.interviewerConfig as InterviewerConfig;
   const isRoundDone = isRoundViewOnly(currentRound?.status, sessionStatus);
 
-  const { messages, input, handleInputChange, handleSubmit, isLoading, resetMessages, sendMessage, setMessages } =
+  const { messages, input, handleInputChange, handleSubmit, isLoading, error: chatError, resetMessages, sendMessage, setMessages } =
     useInterviewChat({
       sessionId,
       roundId: currentRound?.id || '',
-      selectedModel: useSettingsStore.getState().aiModel,
+      selectedModel,
     });
 
   // Load initial messages from DB on first render
@@ -202,6 +206,27 @@ export function InterviewRoom({ sessionId, initialMessages }: InterviewRoomProps
         </div>
       ) : (
         <div className="space-y-2 border-t border-zinc-100 pt-2 pb-2 dark:border-zinc-800">
+          {chatError && (
+            <div role="alert" className="flex items-start gap-2 rounded-xl border border-amber-200 bg-amber-50 p-3 text-amber-700 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-300">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium">{t('chatErrorTitle')}</p>
+                <p className="mt-1 text-xs leading-relaxed opacity-90">{t('chatErrorHint')}</p>
+                {chatError.message && <p className="mt-1 break-words text-[11px] opacity-70">{chatError.message}</p>}
+                <button
+                  type="button"
+                  className="mt-2 inline-flex cursor-pointer items-center gap-1.5 rounded-lg bg-amber-100 px-2.5 py-1.5 text-xs font-medium hover:bg-amber-200 dark:bg-amber-900/50 dark:hover:bg-amber-900"
+                  onClick={() => {
+                    setSettingsTab('ai');
+                    openModal('settings');
+                  }}
+                >
+                  <Settings className="h-3.5 w-3.5" />
+                  {t('openAISettings')}
+                </button>
+              </div>
+            </div>
+          )}
           {controls}
           <MessageInput
             input={input}

--- a/src/components/settings/settings-dialog.tsx
+++ b/src/components/settings/settings-dialog.tsx
@@ -74,6 +74,7 @@ export function SettingsDialog() {
   const [fetchedModels, setFetchedModels] = useState<string[]>([]);
   const [modelsFetching, setModelsFetching] = useState(false);
   const [modelsFetched, setModelsFetched] = useState(false);
+  const [modelsError, setModelsError] = useState<'missing-api-key' | 'fetch' | null>(null);
   const modelSearchRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -85,19 +86,30 @@ export function SettingsDialog() {
   // Fetch models when combobox opens or when apiKey/baseURL changes
   const fetchModels = useCallback(async () => {
     setModelsFetching(true);
+    setModelsError(null);
+    if (!aiApiKey.trim()) {
+      setFetchedModels([]);
+      setModelsFetched(true);
+      setModelsError('missing-api-key');
+      setModelsFetching(false);
+      return;
+    }
+
     try {
       const res = await fetch('/api/ai/models', { headers: getAIHeaders() });
       const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Failed to fetch models');
       const ids = (data.models || []).map((m: { id: string }) => m.id);
       setFetchedModels(ids);
       setModelsFetched(true);
     } catch {
       setFetchedModels([]);
       setModelsFetched(true);
+      setModelsError('fetch');
     } finally {
       setModelsFetching(false);
     }
-  }, []);
+  }, [aiApiKey]);
 
   // Re-fetch models when apiKey or baseURL changes
   const prevKeyRef = useRef(aiApiKey);
@@ -108,6 +120,7 @@ export function SettingsDialog() {
       prevUrlRef.current = aiBaseURL;
       setModelsFetched(false);
       setFetchedModels([]);
+      setModelsError(null);
     }
   }, [aiApiKey, aiBaseURL]);
 
@@ -255,7 +268,19 @@ export function SettingsDialog() {
                       </div>
                     )}
 
-                    {!modelsFetching && filteredModels.length === 0 && modelsFetched && (
+                    {!modelsFetching && modelsError === 'missing-api-key' && (
+                      <div className="px-2 py-3 text-center text-xs text-amber-600 dark:text-amber-400">
+                        {t('ai.modelsMissingApiKey')}
+                      </div>
+                    )}
+
+                    {!modelsFetching && modelsError === 'fetch' && (
+                      <div className="px-2 py-3 text-center text-xs text-red-500">
+                        {t('ai.modelsFetchError')}
+                      </div>
+                    )}
+
+                    {!modelsFetching && !modelsError && filteredModels.length === 0 && modelsFetched && (
                       <div className="py-3 text-center text-xs text-zinc-400">
                         {t('ai.noModelsFound')}
                       </div>

--- a/src/lib/ai/provider.test.ts
+++ b/src/lib/ai/provider.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeAIBaseURL } from './provider';
+
+describe('normalizeAIBaseURL', () => {
+  it('adds /v1 for an OpenAI-compatible host URL', () => {
+    expect(normalizeAIBaseURL('openai', 'https://api.dadakeji.com')).toBe('https://api.dadakeji.com/v1');
+  });
+
+  it('preserves an existing OpenAI-compatible API path', () => {
+    expect(normalizeAIBaseURL('openai', 'https://api.example.com/v1/')).toBe('https://api.example.com/v1');
+  });
+
+  it('does not rewrite non-OpenAI provider URLs', () => {
+    expect(normalizeAIBaseURL('anthropic', 'https://api.anthropic.com/')).toBe('https://api.anthropic.com');
+  });
+});

--- a/src/lib/ai/provider.ts
+++ b/src/lib/ai/provider.ts
@@ -10,6 +10,21 @@ export interface AIConfig {
   model: string;
 }
 
+export function normalizeAIBaseURL(provider: string, baseURL: string) {
+  const trimmed = baseURL.trim().replace(/\/+$/, '');
+  if (!trimmed || provider !== 'openai') return trimmed;
+
+  try {
+    const url = new URL(trimmed);
+    if (url.pathname === '' || url.pathname === '/') {
+      url.pathname = '/v1';
+    }
+    return url.toString().replace(/\/$/, '');
+  } catch {
+    return trimmed;
+  }
+}
+
 export function extractAIConfig(request: NextRequest): AIConfig {
   const provider = request.headers.get('x-provider') || 'openai';
   const apiKey = request.headers.get('x-api-key') || '';
@@ -23,18 +38,19 @@ export function getModel(config: AIConfig, modelOverride?: string) {
     throw new AIConfigError('API key is required. Please configure it in Settings.');
   }
   const modelId = modelOverride || config.model;
+  const baseURL = normalizeAIBaseURL(config.provider, config.baseURL);
 
   switch (config.provider) {
     case 'anthropic': {
-      const p = createAnthropic({ apiKey: config.apiKey, baseURL: config.baseURL || undefined });
+      const p = createAnthropic({ apiKey: config.apiKey, baseURL: baseURL || undefined });
       return p(modelId);
     }
     case 'gemini': {
-      const p = createGoogleGenerativeAI({ apiKey: config.apiKey, baseURL: config.baseURL || undefined });
+      const p = createGoogleGenerativeAI({ apiKey: config.apiKey, baseURL: baseURL || undefined });
       return p(modelId);
     }
     default: {
-      const p = createOpenAI({ apiKey: config.apiKey, baseURL: config.baseURL });
+      const p = createOpenAI({ apiKey: config.apiKey, baseURL });
       return p.chat(modelId);
     }
   }

--- a/src/lib/db/repositories/user.repository.ts
+++ b/src/lib/db/repositories/user.repository.ts
@@ -59,7 +59,17 @@ export const userRepository = {
 
   async getSettings(id: string) {
     const result = await db.select({ settings: users.settings }).from(users).where(eq(users.id, id)).limit(1);
-    return (result[0]?.settings || {}) as Record<string, unknown>;
+    const raw = result[0]?.settings;
+    if (!raw) return {};
+    if (typeof raw === 'string') {
+      try {
+        const parsed = JSON.parse(raw);
+        return parsed && typeof parsed === 'object' ? parsed as Record<string, unknown> : {};
+      } catch {
+        return {};
+      }
+    }
+    return raw as Record<string, unknown>;
   },
 
   async updateSettings(id: string, settings: Record<string, unknown>) {


### PR DESCRIPTION
## Summary

修复缺失 AI API Key 或 AI 请求失败时，面试对话、报告生成和模型选择页面无反馈、无法继续配置的问题。

## Root cause

- 面试聊天接口返回错误后，页面没有显示错误状态或配置入口。
- 报告页未检查 HTTP 状态，可能把 `{ error: ... }` 当作报告数据处理。
- 模型列表接口在缺少 API Key 时返回 200 和空数组，设置页看起来像没有响应。
- 用户设置从数据库读取 JSON 字符串时被直接展开，首次保存可能产生错误字段。

## Changes

- 在面试房间和报告页增加明确的错误提示及跳转 AI 设置按钮。
- 对面试数据和报告生成请求检查响应状态，并展示后端错误信息。
- 缺少 API Key 时，模型列表接口返回 401；设置页区分缺少 Key 与请求失败。
- 安全解析数据库中的设置 JSON，并让面试模型选择对设置变化保持响应。
- OpenAI 兼容服务的根地址自动规范为 `/v1`，避免请求落到服务网页而不是模型接口。
- 面试流禁用重复重试并增加 60 秒超时，第三方接口不响应时可以结束并显示错误。
- 补充中英文提示文案。

## Verification

- `pnpm type-check` passed
- `pnpm test` passed: 3 files, 28 tests
- Targeted ESLint passed for changed report/settings/models files
- Runtime checks confirmed models and report endpoints return 401 without an API Key, while the report page still loads with HTTP 200
- Provider checks confirmed `https://api.dadakeji.com/chat/completions` returns the gateway HTML page, while `/v1/chat/completions` reaches the API endpoint; the new normalization covers this configuration.
- Full `pnpm lint` remains blocked by pre-existing repository-wide lint debt: 1,289 errors and 71 warnings
